### PR TITLE
Add schedule save button component

### DIFF
--- a/app/[locale]/[workspaceid]/chat/[chatid]/page.tsx
+++ b/app/[locale]/[workspaceid]/chat/[chatid]/page.tsx
@@ -33,18 +33,11 @@ export default function ChatIDPage() {
 
   return (
     <>
-      <ChatUI setSchedule={setSchedule} />
-
-      {schedule.length > 0 && (
-        <div className="fixed bottom-4 left-1/2 z-50 -translate-x-1/2">
-          <button
-            className="rounded bg-green-600 px-4 py-2 font-semibold text-white hover:bg-green-700"
-            onClick={handleSaveSchedule}
-          >
-            💾 Save Schedule
-          </button>
-        </div>
-      )}
+      <ChatUI
+        setSchedule={setSchedule}
+        schedule={schedule}
+        onSaveSchedule={handleSaveSchedule}
+      />
     </>
   )
 }

--- a/components/chat/chat-messages.tsx
+++ b/components/chat/chat-messages.tsx
@@ -4,9 +4,15 @@ import { Tables } from "@/supabase/types"
 import { FC, useContext, useState } from "react"
 import { Message } from "../messages/message"
 
-interface ChatMessagesProps {}
+interface ChatMessagesProps {
+  schedule: { time: string; activity: string; note?: string }[]
+  onSaveSchedule: () => void
+}
 
-export const ChatMessages: FC<ChatMessagesProps> = ({}) => {
+export const ChatMessages: FC<ChatMessagesProps> = ({
+  schedule,
+  onSaveSchedule
+}) => {
   const { chatMessages, chatFileItems } = useContext(ChatbotUIContext)
 
   const { handleSendEdit } = useChatHandler()
@@ -32,6 +38,8 @@ export const ChatMessages: FC<ChatMessagesProps> = ({}) => {
           onStartEdit={setEditingMessage}
           onCancelEdit={() => setEditingMessage(undefined)}
           onSubmitEdit={handleSendEdit}
+          schedule={schedule}
+          onSaveSchedule={onSaveSchedule}
         />
       )
     })

--- a/components/chat/chat-ui.tsx
+++ b/components/chat/chat-ui.tsx
@@ -22,6 +22,8 @@ import { ChatSecondaryButtons } from "./chat-secondary-buttons"
 
 interface ChatUIProps {
   setSchedule: (s: { time: string; activity: string; note?: string }[]) => void
+  schedule: { time: string; activity: string; note?: string }[]
+  onSaveSchedule: () => void
 }
 
 export const ChatUI: FC<ChatUIProps> = props => {
@@ -231,7 +233,10 @@ export const ChatUI: FC<ChatUIProps> = props => {
       >
         <div ref={messagesStartRef} />
 
-        <ChatMessages />
+        <ChatMessages
+          schedule={props.schedule}
+          onSaveSchedule={props.onSaveSchedule}
+        />
 
         <div ref={messagesEndRef} />
       </div>

--- a/components/messages/message-actions.tsx
+++ b/components/messages/message-actions.tsx
@@ -2,6 +2,7 @@ import { ChatbotUIContext } from "@/context/context"
 import { IconCheck, IconCopy, IconEdit, IconRepeat } from "@tabler/icons-react"
 import { FC, useContext, useEffect, useState } from "react"
 import { WithTooltip } from "../ui/with-tooltip"
+import { ScheduleSaveButton } from "./schedule-save-button"
 
 export const MESSAGE_ICON_SIZE = 18
 
@@ -13,6 +14,8 @@ interface MessageActionsProps {
   onCopy: () => void
   onEdit: () => void
   onRegenerate: () => void
+  schedule?: { time: string; activity: string; note?: string }[]
+  onSaveSchedule?: () => void
 }
 
 export const MessageActions: FC<MessageActionsProps> = ({
@@ -22,7 +25,9 @@ export const MessageActions: FC<MessageActionsProps> = ({
   isHovering,
   onCopy,
   onEdit,
-  onRegenerate
+  onRegenerate,
+  schedule,
+  onSaveSchedule
 }) => {
   const { isGenerating } = useContext(ChatbotUIContext)
 
@@ -92,6 +97,20 @@ export const MessageActions: FC<MessageActionsProps> = ({
                 onClick={handleCopy}
               />
             )
+          }
+        />
+      )}
+
+      {isAssistant && isLast && schedule && schedule.length > 0 && (
+        <WithTooltip
+          delayDuration={1000}
+          side="bottom"
+          display={<div>Save Schedule</div>}
+          trigger={
+            <ScheduleSaveButton
+              size={MESSAGE_ICON_SIZE}
+              onClick={onSaveSchedule}
+            />
           }
         />
       )}

--- a/components/messages/message.tsx
+++ b/components/messages/message.tsx
@@ -34,6 +34,8 @@ interface MessageProps {
   onStartEdit: (message: Tables<"messages">) => void
   onCancelEdit: () => void
   onSubmitEdit: (value: string, sequenceNumber: number) => void
+  schedule: { time: string; activity: string; note?: string }[]
+  onSaveSchedule: () => void
 }
 
 export const Message: FC<MessageProps> = ({
@@ -43,7 +45,9 @@ export const Message: FC<MessageProps> = ({
   isLast,
   onStartEdit,
   onCancelEdit,
-  onSubmitEdit
+  onSubmitEdit,
+  schedule,
+  onSaveSchedule
 }) => {
   const {
     assistants,
@@ -199,6 +203,8 @@ export const Message: FC<MessageProps> = ({
             isEditing={isEditing}
             isHovering={isHovering}
             onRegenerate={handleRegenerate}
+            schedule={schedule}
+            onSaveSchedule={onSaveSchedule}
           />
         </div>
         <div className="space-y-3">

--- a/components/messages/schedule-save-button.tsx
+++ b/components/messages/schedule-save-button.tsx
@@ -1,0 +1,20 @@
+import { FC } from "react"
+import { IconDeviceFloppy } from "@tabler/icons-react"
+
+interface ScheduleSaveButtonProps {
+  onClick: () => void
+  size?: number
+}
+
+export const ScheduleSaveButton: FC<ScheduleSaveButtonProps> = ({
+  onClick,
+  size = 18
+}) => {
+  return (
+    <IconDeviceFloppy
+      className="cursor-pointer hover:opacity-50"
+      size={size}
+      onClick={onClick}
+    />
+  )
+}


### PR DESCRIPTION
## Summary
- create `ScheduleSaveButton` component
- integrate the new button into `MessageActions`
- propagate schedule data and save callback down to `MessageActions`
- remove floating save button from chat page

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: missing dependencies)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68400fd16ff4832796db72a77a8dd5ff